### PR TITLE
Update to work with Xcode 9

### DIFF
--- a/install_templates.sh
+++ b/install_templates.sh
@@ -8,5 +8,5 @@ rm -fR ~/Library/Developer/Xcode/Templates/File\ Templates/ustwo\ VIP\ Templates
 # Create directory
 mkdir -p ~/Library/Developer/Xcode/Templates/File\ Templates/ustwo\ VIP\ Templates
 
-# Copy all included templates to the templates directory 
+# Copy all included templates to the templates directory
 cp -R ustwo\ VIP\ Templates ~/Library/Developer/Xcode/Templates/File\ Templates/

--- a/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Configurator/___FILEBASENAME___Configurator.swift
+++ b/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Configurator/___FILEBASENAME___Configurator.swift
@@ -8,21 +8,21 @@
 
 import UIKit
 
-final class ___FILEBASENAMEASIDENTIFIER___Configurator {
+final class ___VARIABLE_sceneName___Configurator {
 
 
     // MARK: - Singleton
 
-    static let sharedInstance: ___FILEBASENAMEASIDENTIFIER___Configurator = ___FILEBASENAMEASIDENTIFIER___Configurator()
+    static let sharedInstance: ___VARIABLE_sceneName___Configurator = ___VARIABLE_sceneName___Configurator()
 
 
     // MARK: - Configuration
 
-    func configure(viewController: ___FILEBASENAMEASIDENTIFIER___ViewController) {
+    func configure(viewController: ___VARIABLE_sceneName___ViewController) {
 
-        let router = ___FILEBASENAMEASIDENTIFIER___Router(viewController: viewController)
-        let presenter = ___FILEBASENAMEASIDENTIFIER___Presenter(output: viewController)
-        let interactor = ___FILEBASENAMEASIDENTIFIER___Interactor(output: presenter)
+        let router = ___VARIABLE_sceneName___Router(viewController: viewController)
+        let presenter = ___VARIABLE_sceneName___Presenter(output: viewController)
+        let interactor = ___VARIABLE_sceneName___Interactor(output: presenter)
 
         viewController.output = interactor
         viewController.router = router

--- a/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Interactor/___FILEBASENAME___Interactor.swift
+++ b/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Interactor/___FILEBASENAME___Interactor.swift
@@ -8,24 +8,24 @@
 
 import UIKit
 
-protocol ___FILEBASENAMEASIDENTIFIER___InteractorInput: ___FILEBASENAMEASIDENTIFIER___ViewControllerOutput {
+protocol ___VARIABLE_sceneName___InteractorInput: ___VARIABLE_sceneName___ViewControllerOutput {
 
 }
 
-protocol ___FILEBASENAMEASIDENTIFIER___InteractorOutput {
+protocol ___VARIABLE_sceneName___InteractorOutput {
 
     func presentSomething()
 }
 
-final class ___FILEBASENAMEASIDENTIFIER___Interactor {
+final class ___VARIABLE_sceneName___Interactor {
 
-    let output: ___FILEBASENAMEASIDENTIFIER___InteractorOutput
-    let worker: ___FILEBASENAMEASIDENTIFIER___Worker
+    let output: ___VARIABLE_sceneName___InteractorOutput
+    let worker: ___VARIABLE_sceneName___Worker
 
 
     // MARK: - Initializers
 
-    init(output: ___FILEBASENAMEASIDENTIFIER___InteractorOutput, worker: ___FILEBASENAMEASIDENTIFIER___Worker = ___FILEBASENAMEASIDENTIFIER___Worker()) {
+    init(output: ___VARIABLE_sceneName___InteractorOutput, worker: ___VARIABLE_sceneName___Worker = ___VARIABLE_sceneName___Worker()) {
 
         self.output = output
         self.worker = worker
@@ -33,9 +33,9 @@ final class ___FILEBASENAMEASIDENTIFIER___Interactor {
 }
 
 
-// MARK: - ___FILEBASENAMEASIDENTIFIER___InteractorInput
+// MARK: - ___VARIABLE_sceneName___InteractorInput
 
-extension ___FILEBASENAMEASIDENTIFIER___Interactor: ___FILEBASENAMEASIDENTIFIER___ViewControllerOutput {
+extension ___VARIABLE_sceneName___Interactor: ___VARIABLE_sceneName___ViewControllerOutput {
 
 
     // MARK: - Business logic

--- a/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Presenter/___FILEBASENAME___Presenter.swift
+++ b/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Presenter/___FILEBASENAME___Presenter.swift
@@ -8,32 +8,32 @@
 
 import UIKit
 
-protocol ___FILEBASENAMEASIDENTIFIER___PresenterInput: ___FILEBASENAMEASIDENTIFIER___InteractorOutput {
+protocol ___VARIABLE_sceneName___PresenterInput: ___VARIABLE_sceneName___InteractorOutput {
 
 }
 
-protocol ___FILEBASENAMEASIDENTIFIER___PresenterOutput: class {
+protocol ___VARIABLE_sceneName___PresenterOutput: class {
 
-    func displaySomething(viewModel: ___FILEBASENAMEASIDENTIFIER___ViewModel)
+    func displaySomething(viewModel: ___VARIABLE_sceneName___ViewModel)
 }
 
-final class ___FILEBASENAMEASIDENTIFIER___Presenter {
+final class ___VARIABLE_sceneName___Presenter {
 
-    private(set) weak var output: ___FILEBASENAMEASIDENTIFIER___PresenterOutput!
+    private(set) weak var output: ___VARIABLE_sceneName___PresenterOutput!
 
 
     // MARK: - Initializers
 
-    init(output: ___FILEBASENAMEASIDENTIFIER___PresenterOutput) {
+    init(output: ___VARIABLE_sceneName___PresenterOutput) {
 
         self.output = output
     }
 }
 
 
-// MARK: - ___FILEBASENAMEASIDENTIFIER___PresenterInput
+// MARK: - ___VARIABLE_sceneName___PresenterInput
 
-extension ___FILEBASENAMEASIDENTIFIER___Presenter: ___FILEBASENAMEASIDENTIFIER___PresenterInput {
+extension ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresenterInput {
 
 
     // MARK: - Presentation logic
@@ -42,7 +42,7 @@ extension ___FILEBASENAMEASIDENTIFIER___Presenter: ___FILEBASENAMEASIDENTIFIER__
 
         // TODO: Format the response from the Interactor and pass the result back to the View Controller
 
-        let viewModel = ___FILEBASENAMEASIDENTIFIER___ViewModel()
+        let viewModel = ___VARIABLE_sceneName___ViewModel()
         output.displaySomething(viewModel: viewModel)
     }
 }

--- a/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Router/___FILEBASENAME___Router.swift
+++ b/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Router/___FILEBASENAME___Router.swift
@@ -8,30 +8,30 @@
 
 import UIKit
 
-protocol ___FILEBASENAMEASIDENTIFIER___RouterProtocol {
+protocol ___VARIABLE_sceneName___RouterProtocol {
 
-    weak var viewController: ___FILEBASENAMEASIDENTIFIER___ViewController? { get }
+    weak var viewController: ___VARIABLE_sceneName___ViewController? { get }
 
     func navigateToSomewhere()
 }
 
-final class ___FILEBASENAMEASIDENTIFIER___Router {
+final class ___VARIABLE_sceneName___Router {
 
-    weak var viewController: ___FILEBASENAMEASIDENTIFIER___ViewController?
+    weak var viewController: ___VARIABLE_sceneName___ViewController?
 
 
     // MARK: - Initializers
 
-    init(viewController: ___FILEBASENAMEASIDENTIFIER___ViewController?) {
+    init(viewController: ___VARIABLE_sceneName___ViewController?) {
 
         self.viewController = viewController
     }
 }
 
 
-// MARK: - ___FILEBASENAMEASIDENTIFIER___RouterProtocol
+// MARK: - ___VARIABLE_sceneName___RouterProtocol
 
-extension ___FILEBASENAMEASIDENTIFIER___Router: ___FILEBASENAMEASIDENTIFIER___RouterProtocol {
+extension ___VARIABLE_sceneName___Router: ___VARIABLE_sceneName___RouterProtocol {
 
 
     // MARK: - Navigation

--- a/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/View/___FILEBASENAME___ViewController.swift
+++ b/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/View/___FILEBASENAME___ViewController.swift
@@ -8,24 +8,24 @@
 
 import UIKit
 
-protocol ___FILEBASENAMEASIDENTIFIER___ViewControllerInput: ___FILEBASENAMEASIDENTIFIER___PresenterOutput {
+protocol ___VARIABLE_sceneName___ViewControllerInput: ___VARIABLE_sceneName___PresenterOutput {
 
 }
 
-protocol ___FILEBASENAMEASIDENTIFIER___ViewControllerOutput {
+protocol ___VARIABLE_sceneName___ViewControllerOutput {
 
     func doSomething()
 }
 
-final class ___FILEBASENAMEASIDENTIFIER___ViewController: UIViewController {
+final class ___VARIABLE_sceneName___ViewController: UIViewController {
 
-    var output: ___FILEBASENAMEASIDENTIFIER___ViewControllerOutput!
-    var router: ___FILEBASENAMEASIDENTIFIER___RouterProtocol!
+    var output: ___VARIABLE_sceneName___ViewControllerOutput!
+    var router: ___VARIABLE_sceneName___RouterProtocol!
 
 
     // MARK: - Initializers
 
-    init(configurator: ___FILEBASENAMEASIDENTIFIER___Configurator = ___FILEBASENAMEASIDENTIFIER___Configurator.sharedInstance) {
+    init(configurator: ___VARIABLE_sceneName___Configurator = ___VARIABLE_sceneName___Configurator.sharedInstance) {
 
         super.init(nibName: nil, bundle: nil)
 
@@ -42,7 +42,7 @@ final class ___FILEBASENAMEASIDENTIFIER___ViewController: UIViewController {
 
     // MARK: - Configurator
 
-    private func configure(configurator: ___FILEBASENAMEASIDENTIFIER___Configurator = ___FILEBASENAMEASIDENTIFIER___Configurator.sharedInstance) {
+    private func configure(configurator: ___VARIABLE_sceneName___Configurator = ___VARIABLE_sceneName___Configurator.sharedInstance) {
 
         configurator.configure(viewController: self)
     }
@@ -69,14 +69,14 @@ final class ___FILEBASENAMEASIDENTIFIER___ViewController: UIViewController {
 }
 
 
-// MARK: - ___FILEBASENAMEASIDENTIFIER___PresenterOutput
+// MARK: - ___VARIABLE_sceneName___PresenterOutput
 
-extension ___FILEBASENAMEASIDENTIFIER___ViewController: ___FILEBASENAMEASIDENTIFIER___ViewControllerInput {
+extension ___VARIABLE_sceneName___ViewController: ___VARIABLE_sceneName___ViewControllerInput {
 
 
     // MARK: - Display logic
 
-    func displaySomething(viewModel: ___FILEBASENAMEASIDENTIFIER___ViewModel) {
+    func displaySomething(viewModel: ___VARIABLE_sceneName___ViewModel) {
 
         // TODO: Update UI
     }

--- a/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/ViewModel/___FILEBASENAME___ViewModel.swift
+++ b/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/ViewModel/___FILEBASENAME___ViewModel.swift
@@ -8,6 +8,6 @@
 
 import UIKit
 
-struct ___FILEBASENAMEASIDENTIFIER___ViewModel {
+struct ___VARIABLE_sceneName___ViewModel {
 
 }

--- a/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Worker/___FILEBASENAME___Worker.swift
+++ b/ustwo VIP Templates/Scene.xctemplate/___FILEBASENAME___/Worker/___FILEBASENAME___Worker.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ___FILEBASENAMEASIDENTIFIER___Worker {
+class ___VARIABLE_sceneName___Worker {
 
 
     // MARK: - Business Logic


### PR DESCRIPTION
Using `___FILEBASENAMEASIDENTIFIER___` in Xcode 9 was giving weird "ViewController" suffix to class and protocol names. For example, if a scene is named Edit, the ViewController would be named `EditViewControllerViewController`. Changing this to` ___VARIABLE_sceneName___` fixes this.